### PR TITLE
Improve key hints and column detection

### DIFF
--- a/functions/ui-styles.ps1
+++ b/functions/ui-styles.ps1
@@ -69,3 +69,22 @@ function New-InfoTooltip {
     $_toolTips += $tip
 }
 
+# Ajoute un texte indicatif (placeholder) dans une zone de saisie
+Add-Type @"
+using System;
+using System.Runtime.InteropServices;
+public class Win32 {
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    public static extern IntPtr SendMessage(IntPtr hWnd, int msg, int wParam, string lParam);
+}
+"@
+
+$EM_SETCUEBANNER = 0x1501
+function Set-TextBoxPlaceholder {
+    param(
+        [System.Windows.Forms.TextBox]$TextBox,
+        [string]$Text
+    )
+    [Win32]::SendMessage($TextBox.Handle, $EM_SETCUEBANNER, 0, $Text) | Out-Null
+}
+


### PR DESCRIPTION
## Summary
- show placeholders and clearer tooltips for key and IV
- include BNF header in automatic column detection
- update status message to be generic

## Testing
- ❌ `pwsh -NoProfile -Command "Write-Host 'PowerShell available'"` (failed to run `pwsh`)
