### PR TITLE
Corrige le conflit de paramètre IV

### DIFF
--- a/functions/crypt-functions.ps1
+++ b/functions/crypt-functions.ps1
@@ -4,12 +4,12 @@ function ConvertTo-SecureAESKey {
         [Parameter(Mandatory = $true)]
         [string]$KeyString,
         [Parameter(Mandatory = $true)]
-        [string]$IVString
+        [string]$InitVector
     )
     
     # S'assurer que la clé et l'IV sont de la bonne longueur pour AES-256-CBC
     $KeyBytes = [System.Text.Encoding]::UTF8.GetBytes($KeyString)
-    $IVBytes = [System.Text.Encoding]::UTF8.GetBytes($IVString)
+    $IVBytes = [System.Text.Encoding]::UTF8.GetBytes($InitVector)
     
     # Ajuster la taille de la clé à 32 octets (256 bits)
     if ($KeyBytes.Length -gt 32) {
@@ -40,7 +40,7 @@ function Protect-NNSSData {
         [Parameter(Mandatory = $true)]
         [byte[]]$Key,
         [Parameter(Mandatory = $true)]
-        [byte[]]$IV
+        [byte[]]$InitVector
     )
     
     try {
@@ -50,7 +50,7 @@ function Protect-NNSSData {
         # Créer un objet de cryptage AES
         $AES = [System.Security.Cryptography.Aes]::Create()
         $AES.Key = $Key
-        $AES.IV = $IV
+        $AES.IV = $InitVector
         $AES.Mode = [System.Security.Cryptography.CipherMode]::CBC
         $AES.Padding = [System.Security.Cryptography.PaddingMode]::PKCS7
         
@@ -81,7 +81,7 @@ function Unprotect-NNSSData {
         [Parameter(Mandatory = $true)]
         [byte[]]$Key,
         [Parameter(Mandatory = $true)]
-        [byte[]]$IV
+        [byte[]]$InitVector
     )
     
     try {
@@ -91,7 +91,7 @@ function Unprotect-NNSSData {
         # Créer un objet de décryptage AES
         $AES = [System.Security.Cryptography.Aes]::Create()
         $AES.Key = $Key
-        $AES.IV = $IV
+        $AES.IV = $InitVector
         $AES.Mode = [System.Security.Cryptography.CipherMode]::CBC
         $AES.Padding = [System.Security.Cryptography.PaddingMode]::PKCS7
         
@@ -194,7 +194,7 @@ function Process-CSVFile {
         [Parameter(Mandatory = $true)]
         [byte[]]$Key,
         [Parameter(Mandatory = $true)]
-        [byte[]]$IV,
+        [byte[]]$InitVector,
         [Parameter(Mandatory = $true)]
         [bool]$IsEncryption
     )
@@ -218,11 +218,11 @@ function Process-CSVFile {
                 if (![string]::IsNullOrEmpty($originalValue)) {
                     if ($IsEncryption) {
                         # Crypter
-                        $newValue = Protect-NNSSData -InputText $originalValue -Key $Key -IV $IV
+                        $newValue = Protect-NNSSData -InputText $originalValue -Key $Key -InitVector $InitVector
                     }
                     else {
                         # Décrypter
-                        $newValue = Unprotect-NNSSData -EncryptedText $originalValue -Key $Key -IV $IV
+                        $newValue = Unprotect-NNSSData -EncryptedText $originalValue -Key $Key -InitVector $InitVector
                     }
                     
                     if ($newValue -ne $null) {
@@ -254,7 +254,7 @@ function Process-ExcelFile {
         [Parameter(Mandatory = $true)]
         [byte[]]$Key,
         [Parameter(Mandatory = $true)]
-        [byte[]]$IV,
+        [byte[]]$InitVector,
         [Parameter(Mandatory = $true)]
     [bool]$IsEncryption
     )
@@ -305,11 +305,11 @@ function Process-ExcelFile {
             if (![string]::IsNullOrEmpty($cellValue)) {
                 if ($IsEncryption) {
                     # Crypter
-                    $newValue = Protect-NNSSData -InputText $cellValue -Key $Key -IV $IV
+                    $newValue = Protect-NNSSData -InputText $cellValue -Key $Key -InitVector $InitVector
                 }
                 else {
                     # Décrypter
-                    $newValue = Unprotect-NNSSData -EncryptedText $cellValue -Key $Key -IV $IV
+                    $newValue = Unprotect-NNSSData -EncryptedText $cellValue -Key $Key -InitVector $InitVector
                 }
                 
                 if ($newValue -ne $null) {

--- a/nnss-crypt.ps1
+++ b/nnss-crypt.ps1
@@ -530,7 +530,7 @@ $processButton.Add_Click({
         }
         
         # Obtenir les paramètres de cryptage
-        $cryptoParams = ConvertTo-SecureAESKey -KeyString $keyTextBox.Text -IVString $ivTextBox.Text
+        $cryptoParams = ConvertTo-SecureAESKey -KeyString $keyTextBox.Text -InitVector $ivTextBox.Text
         
         # Configurer le traitement
         $inputFilePath = $inputFileTextBox.Text
@@ -561,10 +561,10 @@ $processButton.Add_Click({
 
         try {
             if ($extension -eq ".csv") {
-                $result = Process-CSVFile -InputFilePath $inputFilePath -OutputFilePath $outputFilePath -ColumnName $columnName -Key $cryptoParams.Key -IV $cryptoParams.IV -IsEncryption $isEncryption
+                $result = Process-CSVFile -InputFilePath $inputFilePath -OutputFilePath $outputFilePath -ColumnName $columnName -Key $cryptoParams.Key -InitVector $cryptoParams.IV -IsEncryption $isEncryption
             }
             elseif ($extension -eq ".xlsx" -or $extension -eq ".xls") {
-                $result = Process-ExcelFile -InputFilePath $inputFilePath -OutputFilePath $outputFilePath -ColumnName $columnName -Key $cryptoParams.Key -IV $cryptoParams.IV -IsEncryption $isEncryption
+                $result = Process-ExcelFile -InputFilePath $inputFilePath -OutputFilePath $outputFilePath -ColumnName $columnName -Key $cryptoParams.Key -InitVector $cryptoParams.IV -IsEncryption $isEncryption
             }
             else {
                 throw "Format de fichier non pris en charge."


### PR DESCRIPTION
## Notes
Aucun test automatique n'est fourni dans ce dépôt.

## Summary
- renomme `-IV` en `-InitVector` dans les fonctions PowerShell
- met à jour les appels correspondants dans `nnss-crypt.ps1`
