### PR TITLE
Ajout validation Base64 et logs de traitement

### DIFF
--- a/nnss-crypt.ps1
+++ b/nnss-crypt.ps1
@@ -572,7 +572,15 @@ $processButton.Add_Click({
 
             if ($result) {
                 $operation = if ($isEncryption) { "cryptage" } else { "décryptage" }
-                [System.Windows.MessageBox]::Show("Le $operation a été effectué avec succès.", "Succès", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+
+                $warningCount = (Get-Job | Where-Object { $_.State -eq "Completed" } | Receive-Job -WarningVariable warnings).Count
+
+                if ($warningCount -gt 0) {
+                    [System.Windows.MessageBox]::Show("Le $operation a été effectué avec $warningCount avertissement(s). Vérifiez les valeurs dans le fichier de sortie.", "Succès avec avertissements", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Warning)
+                } else {
+                    [System.Windows.MessageBox]::Show("Le $operation a été effectué avec succès.", "Succès", [System.Windows.MessageBoxButton]::OK, [System.Windows.MessageBoxImage]::Information)
+                }
+
                 $statusLabel.Text = "Traitement terminé avec succès."
             }
         }


### PR DESCRIPTION
## Notes
- PowerShell n'est pas installé dans l'environnement de test, les scripts n'ont donc pas pu être exécutés.

## Summary
- ajout d'une fonction `Test-Base64String` pour vérifier les chaînes
- protection/déprotection améliorées avec messages d'erreur détaillés
- suivi du nombre de valeurs traitées, en erreur ou ignorées dans `Process-CSVFile`
- affichage conditionnel d'un message d'avertissement dans l'interface

## Testing
- `pwsh -NoLogo -NoProfile -Command "Write-Output 'PowerShell OK'"` *(fails: command not found)*